### PR TITLE
fix: finalize v1.6.20 issue closure

### DIFF
--- a/RELEASE_NOTES_1.6.20.md
+++ b/RELEASE_NOTES_1.6.20.md
@@ -1,0 +1,19 @@
+# OC Remote v1.6.20 — Beta Test Release Notes（测试版发布说明）
+
+## Beta release scope
+
+- This is a beta/test release build for closing and validating #10, #11, #14, #15, and #16.
+- Android metadata is bumped to `versionName` `1.6.20` and `versionCode` `33`.
+
+## Issue closure and validation notes
+
+- **#10 — unread lifecycle and live command logs**: unread main-session handling is included, expanded command/tool cards can show live execution logs, and the chat lifecycle clears the active session by matching session id so leaving an old chat cannot clear a newer visible chat.
+- **#11 — release artifact versioning**: manual release workflow hardening is included for beta validation, including building from the requested tag and checking APK metadata before publishing.
+- **#14 — MCP management / empty-project handling**: MCP list states, session archiving, and empty project visibility/opening changes are included for regression validation.
+- **#15 — update progress and management UX**: update downloads now surface progress details, with the related management-state fixes included in this beta test build.
+- **#16 — root project sessions**: per-project session loading keeps root-project sessions visible so projects with existing root sessions do not appear empty.
+
+## Version
+
+- `versionName`: `1.6.20`
+- `versionCode`: `33`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "dev.minios.ocremote"
         minSdk = 26
         targetSdk = 34
-        versionCode = 32
-        versionName = "1.6.19"
+        versionCode = 33
+        versionName = "1.6.20"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/kotlin/dev/minios/ocremote/data/repository/EventReducer.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/repository/EventReducer.kt
@@ -384,8 +384,8 @@ class EventReducer @Inject constructor() {
     }
 
     fun clearActiveSessionId(sessionId: String) {
-        if (_activeSessionId.value == sessionId) {
-            _activeSessionId.value = null
+        _activeSessionId.update { activeSessionId ->
+            if (activeSessionId == sessionId) null else activeSessionId
         }
     }
     

--- a/app/src/test/kotlin/dev/minios/ocremote/data/repository/EventReducerActiveSessionTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/data/repository/EventReducerActiveSessionTest.kt
@@ -16,11 +16,12 @@ class EventReducerActiveSessionTest {
     }
 
     @Test
-    fun clearActiveSessionIdOnlyClearsMatchingSession() {
+    fun clearActiveSessionIdDoesNotClearNewerActiveSession() {
         val reducer = EventReducer()
+        reducer.setActiveSessionId("ses_stale")
         reducer.setActiveSessionId("ses_visible")
 
-        reducer.clearActiveSessionId("other")
+        reducer.clearActiveSessionId("ses_stale")
         assertEquals("ses_visible", reducer.activeSessionId.value)
 
         reducer.clearActiveSessionId("ses_visible")


### PR DESCRIPTION
## Summary
- Finalize the unread active-session lifecycle guard for #10 by keeping stale chat cleanup from clearing a newer visible session.
- Bump the beta/test release metadata to v1.6.20 / versionCode 33.
- Add v1.6.20 release notes covering closure validation for #10, #11, #14, #15, and #16.

## Verification
- `git diff --check` passed locally.
- Local Gradle execution is blocked on this host by repeated Gradle 8.6 distribution download timeouts; release workflow will perform the authoritative remote build for v1.6.20.