### PR TITLE
fix: require signed release APK publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,16 +61,28 @@ jobs:
       - name: Grant execute permissions for gradlew
         run: chmod +x ./gradlew
 
+      - name: Validate signing secrets
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ] || [ -z "$KEYSTORE_ALIAS" ] || [ -z "$KEYSTORE_PASSWORD" ]; then
+            echo "::error::Release signing secrets are required: KEYSTORE_BASE64, KEYSTORE_ALIAS, KEYSTORE_PASSWORD"
+            exit 1
+          fi
+
       - name: Decode Keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
-        if: ${{ env.KEYSTORE_BASE64 != '' }}
+          KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         run: |
           mkdir -p app/keystore
-          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > app/keystore/release.keystore
+          echo "$KEYSTORE_BASE64" | base64 -d > app/keystore/release.keystore
           echo "keystore=keystore/release.keystore" > app/keystore/signing.properties
-          echo "keystore.alias=${{ secrets.KEYSTORE_ALIAS }}" >> app/keystore/signing.properties
-          echo "keystore.password=${{ secrets.KEYSTORE_PASSWORD }}" >> app/keystore/signing.properties
+          echo "keystore.alias=$KEYSTORE_ALIAS" >> app/keystore/signing.properties
+          echo "keystore.password=$KEYSTORE_PASSWORD" >> app/keystore/signing.properties
 
       - name: Build Release APK
         run: ./gradlew clean :app:assembleRelease
@@ -128,6 +140,16 @@ jobs:
 
           echo "Verified output-metadata.json versionName=$ACTUAL_VERSION versionCode=$ACTUAL_CODE"
 
+      - name: Verify release APK signature
+        run: |
+          APK_PATH="${{ steps.package_apk.outputs.apk }}"
+          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort -V | tail -1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "::error::apksigner not found in Android SDK build-tools"
+            exit 1
+          fi
+          "$APKSIGNER" verify --verbose "$APK_PATH"
+
       - name: Upload Release APK
         uses: actions/upload-artifact@v4
         with:
@@ -145,12 +167,7 @@ jobs:
 
           # Check if release already exists
           if gh release view "$TAG" > /dev/null 2>&1; then
-            echo "Release $TAG already exists, cleaning previous APK assets..."
-            for ASSET_ID in $(gh release view "$TAG" --json assets --jq '.assets[] | select(.name | endswith(".apk")) | .id'); do
-              gh api "repos/${{ github.repository }}/releases/assets/${ASSET_ID}" -X DELETE
-            done
-
-            echo "Uploading current APK..."
+            echo "Release $TAG already exists, uploading current APK with --clobber..."
             gh release upload "$TAG" "$APK_PATH" --clobber
           else
             echo "Creating new release $TAG..."

--- a/RELEASE_NOTES_1.6.21.md
+++ b/RELEASE_NOTES_1.6.21.md
@@ -1,0 +1,19 @@
+# OC Remote v1.6.21 — Signed Beta Test Release Notes（签名测试版发布说明）
+
+## Why this release exists
+
+- `v1.6.20` validated the issue-closure code path, but its GitHub Release APK was built without release signing secrets and could be rejected by Android as an invalid package.
+- `v1.6.21` rebuilds the same closure scope with release signing enabled and adds workflow guards so unsigned release APKs cannot be published silently again.
+
+## Included validation scope
+
+- **#10 — unread lifecycle and live command logs**: keeps the active-session cleanup guarded by matching session id, preventing stale chat lifecycle cleanup from clearing a newer visible chat.
+- **#11 — release artifact versioning/signing**: requires release signing secrets, verifies APK metadata, and verifies the APK signature before upload.
+- **#14 — MCP management / empty-project handling**: carries forward MCP list states, archive/restore/delete flow, and empty project visibility/opening fixes.
+- **#15 — update progress**: carries forward update download progress details.
+- **#16 — root project sessions**: carries forward per-project root-session visibility fixes.
+
+## Version
+
+- `versionName`: `1.6.21`
+- `versionCode`: `34`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "dev.minios.ocremote"
         minSdk = 26
         targetSdk = 34
-        versionCode = 33
-        versionName = "1.6.20"
+        versionCode = 34
+        versionName = "1.6.21"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Bump the test release to v1.6.21 / versionCode 34 after the v1.6.20 APK was produced without signing secrets.
- Require release signing secrets before building a release APK.
- Verify the release APK signature with apksigner before upload and avoid the broken asset-delete path when updating releases.

## Verification
- `git diff --check` passed locally.
- Repository Actions secrets are now configured: KEYSTORE_BASE64, KEYSTORE_ALIAS, KEYSTORE_PASSWORD.
- The prior rerun confirmed the keystore decode step now executes; this PR adds hard guards so unsigned APKs cannot be published silently.