### PR TITLE
Fix new session crash with compact API responses

### DIFF
--- a/app/src/main/kotlin/dev/minios/ocremote/data/api/OpenCodeApi.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/api/OpenCodeApi.kt
@@ -1227,7 +1227,7 @@ data class FileNode(
 data class PermissionRequest(
     val id: String,
     @SerialName("sessionID") val sessionId: String,
-    val permission: String,
+    val permission: String = "ask",
     val patterns: List<String> = emptyList(),
     val metadata: Map<String, JsonElement>? = null,
     val always: List<String> = emptyList(),
@@ -1238,23 +1238,23 @@ data class PermissionRequest(
 data class QuestionRequest(
     val id: String,
     @SerialName("sessionID") val sessionId: String,
-    val questions: List<QuestionInfo>,
+    val questions: List<QuestionInfo> = emptyList(),
     val tool: ToolRef? = null
 )
 
 @Serializable
 data class QuestionInfo(
-    val question: String,
-    val header: String,
-    val options: List<QuestionOption>,
+    val question: String = "",
+    val header: String = "",
+    val options: List<QuestionOption> = emptyList(),
     val multiple: Boolean = false,
     val custom: Boolean = true
 )
 
 @Serializable
 data class QuestionOption(
-    val label: String,
-    val description: String
+    val label: String = "",
+    val description: String = ""
 )
 
 // ============ MCP Runtime DTOs ============
@@ -1301,7 +1301,7 @@ internal fun sanitizeMcpError(raw: String?): String? {
 
 @Serializable
 data class ProvidersResponse(
-    val providers: List<ProviderInfo>,
+    val providers: List<ProviderInfo> = emptyList(),
     val default: Map<String, String> = emptyMap()
 )
 
@@ -1345,7 +1345,7 @@ data class ServerConfigPatch(
 @Serializable
 data class ProviderInfo(
     val id: String,
-    val name: String,
+    val name: String = "",
     val source: String = "",
     val env: List<String> = emptyList(),
     val key: String? = null,
@@ -1357,7 +1357,7 @@ data class ProviderInfo(
 data class ProviderModel(
     val id: String,
     @SerialName("providerID") val providerId: String = "",
-    val name: String,
+    val name: String = "",
     val family: String? = null,
     val status: String = "active",
     val capabilities: ModelCapabilities? = null,

--- a/app/src/main/kotlin/dev/minios/ocremote/data/repository/EventReducer.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/repository/EventReducer.kt
@@ -217,8 +217,14 @@ class EventReducer @Inject constructor() {
     }
     
     // ============ Part Events ============
-    
+
+    private fun Part.isRenderablePart(): Boolean {
+        return this !is Part.Tool || (callId.isNotBlank() && tool.isNotBlank())
+    }
+
     private fun handleMessagePartUpdated(event: SseEvent.MessagePartUpdated) {
+        if (!event.part.isRenderablePart()) return
+
         val messageId = event.part.messageId
         _parts.update { current ->
             val messageParts = current[messageId]?.toMutableList() ?: mutableListOf()
@@ -413,7 +419,7 @@ class EventReducer @Inject constructor() {
         _messages.update { it + (sessionId to messages.map { msg -> msg.info }) }
         
         val partsMap = messages.associate { msg ->
-            msg.info.id to msg.parts
+            msg.info.id to msg.parts.filter { it.isRenderablePart() }
         }
         _parts.update { it + partsMap }
     }

--- a/app/src/main/kotlin/dev/minios/ocremote/domain/model/Message.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/domain/model/Message.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable
 data class TimeInfo(
-    val created: Long,
+    val created: Long = 0L,
     val completed: Long? = null
 )
 
@@ -43,7 +43,7 @@ sealed class Message {
         override val id: String,
         @SerialName("sessionID") override val sessionId: String,
         override val role: String = "user",
-        override val time: TimeInfo,
+        override val time: TimeInfo = TimeInfo(),
         val agent: String? = null,
         val model: Model? = null,
         val format: OutputFormat? = null,
@@ -78,8 +78,8 @@ sealed class Message {
         override val id: String,
         @SerialName("sessionID") override val sessionId: String,
         override val role: String = "assistant",
-        override val time: TimeInfo,
-        @SerialName("parentID") val parentId: String,
+        override val time: TimeInfo = TimeInfo(),
+        @SerialName("parentID") val parentId: String? = null,
         @SerialName("modelID") val modelId: String? = null,
         @SerialName("providerID") val providerId: String? = null,
         val agent: String? = null,

--- a/app/src/main/kotlin/dev/minios/ocremote/domain/model/Part.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/domain/model/Part.kt
@@ -74,9 +74,9 @@ sealed class Part {
         override val id: String,
         @SerialName("sessionID") override val sessionId: String,
         @SerialName("messageID") override val messageId: String,
-        @SerialName("callID") val callId: String,
-        val tool: String,
-        val state: ToolState,
+        @SerialName("callID") val callId: String = "",
+        val tool: String = "",
+        val state: ToolState = ToolState.Pending(),
         val metadata: Map<String, JsonElement>? = null
     ) : Part()
 
@@ -119,7 +119,7 @@ sealed class Part {
         override val id: String,
         @SerialName("sessionID") override val sessionId: String,
         @SerialName("messageID") override val messageId: String,
-        val mime: String,
+        val mime: String = "application/octet-stream",
         val filename: String? = null,
         val url: String? = null,
         val source: JsonElement? = null

--- a/app/src/main/kotlin/dev/minios/ocremote/domain/model/Session.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/domain/model/Session.kt
@@ -16,7 +16,7 @@ data class Session(
     @SerialName("parentID") val parentId: String? = null,
     val title: String? = null,
     val version: String = "",
-    val time: Time,
+    val time: Time = Time(),
     val summary: Summary? = null,
     val share: Share? = null,
     val permission: List<PermissionRule>? = null,
@@ -24,8 +24,8 @@ data class Session(
 ) {
     @Serializable
     data class Time(
-        val created: Long,
-        val updated: Long,
+        val created: Long = 0L,
+        val updated: Long = 0L,
         val compacting: Long? = null,
         val archived: Long? = null
     )
@@ -39,11 +39,11 @@ data class Session(
     )
 
     @Serializable
-    data class Share(val url: String)
+    data class Share(val url: String = "")
 
     @Serializable
     data class Revert(
-        @SerialName("messageID") val messageId: String,
+        @SerialName("messageID") val messageId: String = "",
         @SerialName("partID") val partId: String? = null,
         val snapshot: String? = null,
         val diff: String? = null
@@ -51,7 +51,7 @@ data class Session(
 
     @Serializable
     data class PermissionRule(
-        val permission: String,
+        val permission: String = "ask",
         val pattern: String = "*",
         val action: String = "ask"
     )

--- a/app/src/main/kotlin/dev/minios/ocremote/domain/model/SseEvent.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/domain/model/SseEvent.kt
@@ -109,17 +109,17 @@ sealed class SseEvent {
     ) : SseEvent() {
         @Serializable
         data class Question(
-            val header: String,
-            val question: String,
+            val header: String = "",
+            val question: String = "",
             val multiple: Boolean = false,
             val custom: Boolean = true,
-            val options: List<Option>
+            val options: List<Option> = emptyList()
         )
 
         @Serializable
         data class Option(
-            val label: String,
-            val description: String
+            val label: String = "",
+            val description: String = ""
         )
     }
 
@@ -205,5 +205,4 @@ data class Project(
             ?: path.takeIf { it.isNotEmpty() }?.trimEnd('/')?.substringAfterLast('/')?.takeIf { it.isNotEmpty() }
             ?: id.take(8)
 }
-
 

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
@@ -385,7 +385,7 @@ class ChatViewModel @Inject constructor(
             commands = commands,
             hasOlderMessages = hasOlderMessages,
             isLoadingOlder = isLoadingOlder,
-            shareUrl = session?.share?.url,
+            shareUrl = session?.share?.url?.takeIf { it.isNotBlank() },
             contextWindow = currentModel?.limit?.context ?: 0,
             lastContextTokens = lastContextTokens
         )
@@ -397,49 +397,58 @@ class ChatViewModel @Inject constructor(
 
     init {
         eventReducer.setActiveSessionId(sessionId)
-        viewModelScope.launch {
-            sessionListPreferencesRepository.markMainSessionRead(sessionId)
-        }
 
-        // Restore draft from disk
-        val draft = draftRepository.getDraft(sessionId)
-        if (draft != null) {
-            _draftText.value = draft.text
-            _draftAttachmentUris.value = draft.imageUris
-            if (draft.confirmedFilePaths.isNotEmpty()) {
-                _confirmedFilePaths.value = draft.confirmedFilePaths.toSet()
+        // Route guard (issue #27): if sessionId is missing after URL decode,
+        // surface an error state instead of triggering REST calls with an empty sessionId.
+        if (sessionId.isBlank()) {
+            Log.w(TAG, "ChatViewModel constructed with blank sessionId; entering error state")
+            _isLoading.value = false
+            _error.value = "Invalid session"
+        } else {
+            viewModelScope.launch {
+                sessionListPreferencesRepository.markMainSessionRead(sessionId)
             }
-            if (!draft.selectedAgent.isNullOrBlank()) {
-                _selectedAgent.value = draft.selectedAgent to true
-            }
-            if (!draft.selectedVariant.isNullOrBlank()) {
-                _selectedVariant.value = draft.selectedVariant
-            }
-        }
 
-        viewModelScope.launch {
-            settingsRepository.hiddenModels(serverId).collect { hidden ->
-                _hiddenModels.value = hidden
-                applyProviderFilter()
+            // Restore draft from disk
+            val draft = draftRepository.getDraft(sessionId)
+            if (draft != null) {
+                _draftText.value = draft.text
+                _draftAttachmentUris.value = draft.imageUris
+                if (draft.confirmedFilePaths.isNotEmpty()) {
+                    _confirmedFilePaths.value = draft.confirmedFilePaths.toSet()
+                }
+                if (!draft.selectedAgent.isNullOrBlank()) {
+                    _selectedAgent.value = draft.selectedAgent to true
+                }
+                if (!draft.selectedVariant.isNullOrBlank()) {
+                    _selectedVariant.value = draft.selectedVariant
+                }
             }
-        }
 
-        viewModelScope.launch {
-            settingsRepository.terminalFontSize.collect { size ->
-                terminalWorkspace.setDefaultFontSize(size)
+            viewModelScope.launch {
+                settingsRepository.hiddenModels(serverId).collect { hidden ->
+                    _hiddenModels.value = hidden
+                    applyProviderFilter()
+                }
             }
-        }
 
-        // Load initial message count from settings, then load data
-        viewModelScope.launch {
-            currentMessageLimit = settingsRepository.initialMessageCount.first()
-            loadSession()
-            loadMessages()
-            loadPendingQuestions()
+            viewModelScope.launch {
+                settingsRepository.terminalFontSize.collect { size ->
+                    terminalWorkspace.setDefaultFontSize(size)
+                }
+            }
+
+            // Load initial message count from settings, then load data
+            viewModelScope.launch {
+                currentMessageLimit = settingsRepository.initialMessageCount.first()
+                loadSession()
+                loadMessages()
+                loadPendingQuestions()
+            }
+            loadProviders()
+            loadAgents()
+            loadCommands()
         }
-        loadProviders()
-        loadAgents()
-        loadCommands()
 
     }
 

--- a/app/src/test/kotlin/android/util/Log.kt
+++ b/app/src/test/kotlin/android/util/Log.kt
@@ -1,0 +1,21 @@
+package android.util
+
+object Log {
+    @JvmStatic
+    fun d(tag: String?, msg: String?): Int = 0
+
+    @JvmStatic
+    fun d(tag: String?, msg: String?, tr: Throwable?): Int = 0
+
+    @JvmStatic
+    fun e(tag: String?, msg: String?): Int = 0
+
+    @JvmStatic
+    fun e(tag: String?, msg: String?, tr: Throwable?): Int = 0
+
+    @JvmStatic
+    fun w(tag: String?, msg: String?): Int = 0
+
+    @JvmStatic
+    fun w(tag: String?, msg: String?, tr: Throwable?): Int = 0
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/data/api/ProviderCompactJsonTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/data/api/ProviderCompactJsonTest.kt
@@ -1,0 +1,83 @@
+package dev.minios.ocremote.data.api
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProviderCompactJsonTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+        explicitNulls = false
+        isLenient = true
+    }
+
+    @Test
+    fun `providers response with no providers defaults to empty list`() {
+        val response = json.decodeFromString(ProvidersResponse.serializer(), """{}""")
+
+        assertTrue(response.providers.isEmpty())
+        assertTrue(response.default.isEmpty())
+    }
+
+    @Test
+    fun `provider with only id decodes with empty name and models`() {
+        val provider = json.decodeFromString(ProviderInfo.serializer(), """{"id":"openai"}""")
+
+        assertEquals("openai", provider.id)
+        assertEquals("", provider.name)
+        assertTrue(provider.models.isEmpty())
+    }
+
+    @Test
+    fun `provider model with only id decodes with empty name`() {
+        val model = json.decodeFromString(ProviderModel.serializer(), """{"id":"gpt-5"}""")
+
+        assertEquals("gpt-5", model.id)
+        assertEquals("", model.name)
+    }
+
+    @Test
+    fun `full provider response keeps provided names and models`() {
+        val response = json.decodeFromString(
+            ProvidersResponse.serializer(),
+            """
+            {
+              "providers": [
+                {
+                  "id": "openai",
+                  "name": "OpenAI",
+                  "models": {
+                    "gpt-5": {
+                      "id": "gpt-5",
+                      "name": "GPT-5"
+                    }
+                  }
+                }
+              ],
+              "default": { "providerID": "openai", "modelID": "gpt-5" }
+            }
+            """.trimIndent()
+        )
+
+        val provider = response.providers.single()
+        val model = provider.models.getValue("gpt-5")
+        assertEquals("OpenAI", provider.name)
+        assertEquals("GPT-5", model.name)
+        assertEquals("gpt-5", response.default["modelID"])
+    }
+
+    @Test(expected = SerializationException::class)
+    fun `provider id remains required`() {
+        json.decodeFromString(ProviderInfo.serializer(), """{"name":"OpenAI"}""")
+    }
+
+    @Test(expected = SerializationException::class)
+    fun `provider model id remains required`() {
+        json.decodeFromString(ProviderModel.serializer(), """{"name":"GPT-5"}""")
+    }
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/data/api/QuestionPermissionCompactJsonTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/data/api/QuestionPermissionCompactJsonTest.kt
@@ -1,0 +1,103 @@
+package dev.minios.ocremote.data.api
+
+import dev.minios.ocremote.domain.model.SseEvent
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QuestionPermissionCompactJsonTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+        explicitNulls = false
+        isLenient = true
+    }
+
+    @Test
+    fun `decodes pending question with no questions list`() {
+        val req = json.decodeFromString(
+            QuestionRequest.serializer(),
+            """{"id":"q1","sessionID":"s1"}"""
+        )
+        assertEquals("q1", req.id)
+        assertTrue(req.questions.isEmpty())
+    }
+
+    @Test
+    fun `decodes question info with no options`() {
+        val info = json.decodeFromString(
+            QuestionInfo.serializer(),
+            """{"question":"continue?","header":"H"}"""
+        )
+        assertEquals("continue?", info.question)
+        assertEquals("H", info.header)
+        assertTrue(info.options.isEmpty())
+        assertFalse(info.multiple)
+        assertTrue(info.custom)
+    }
+
+    @Test
+    fun `decodes compact question info with empty fields`() {
+        val info = json.decodeFromString(QuestionInfo.serializer(), """{}""")
+        assertEquals("", info.question)
+        assertEquals("", info.header)
+        assertTrue(info.options.isEmpty())
+    }
+
+    @Test
+    fun `decodes question option without description`() {
+        val opt = json.decodeFromString(
+            QuestionOption.serializer(),
+            """{"label":"yes"}"""
+        )
+        assertEquals("yes", opt.label)
+        assertEquals("", opt.description)
+    }
+
+    @Test
+    fun `decodes permission request with no permission field`() {
+        val req = json.decodeFromString(
+            PermissionRequest.serializer(),
+            """{"id":"p1","sessionID":"s1"}"""
+        )
+        assertEquals("ask", req.permission)
+        assertTrue(req.patterns.isEmpty())
+    }
+
+    @Test
+    fun `full permission request round-trips (regression)`() {
+        val req = json.decodeFromString(
+            PermissionRequest.serializer(),
+            """{"id":"p","sessionID":"s","permission":"allow",
+               "patterns":["git/*"],"always":["read"]}"""
+        )
+        assertEquals("allow", req.permission)
+        assertEquals(listOf("git/*"), req.patterns)
+        assertEquals(listOf("read"), req.always)
+    }
+
+    @Test
+    fun `decodes SSE question mirror with compact question`() {
+        val question = json.decodeFromString(
+            SseEvent.QuestionAsked.Question.serializer(),
+            """{}"""
+        )
+        assertEquals("", question.header)
+        assertEquals("", question.question)
+        assertTrue(question.options.isEmpty())
+    }
+
+    @Test
+    fun `decodes SSE question option mirror without description`() {
+        val option = json.decodeFromString(
+            SseEvent.QuestionAsked.Option.serializer(),
+            """{"label":"yes"}"""
+        )
+        assertEquals("yes", option.label)
+        assertEquals("", option.description)
+    }
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/data/repository/EventReducerBadPartFilterTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/data/repository/EventReducerBadPartFilterTest.kt
@@ -1,0 +1,107 @@
+package dev.minios.ocremote.data.repository
+
+import dev.minios.ocremote.domain.model.Message
+import dev.minios.ocremote.domain.model.MessageWithParts
+import dev.minios.ocremote.domain.model.Part
+import dev.minios.ocremote.domain.model.SseEvent
+import dev.minios.ocremote.domain.model.ToolState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EventReducerBadPartFilterTest {
+
+    @Test
+    fun messagePartUpdatedDropsToolPartsWithBlankCallIdOrToolName() {
+        val reducer = EventReducer()
+        val messageId = "msg-1"
+
+        reducer.processEvent(
+            SseEvent.MessagePartUpdated(
+                toolPart(id = "missing-call", messageId = messageId, callId = "", tool = "bash")
+            ),
+            serverId = "server-1",
+        )
+        reducer.processEvent(
+            SseEvent.MessagePartUpdated(
+                toolPart(id = "missing-tool", messageId = messageId, callId = "call-1", tool = "   ")
+            ),
+            serverId = "server-1",
+        )
+
+        assertTrue(reducer.parts.value[messageId].orEmpty().isEmpty())
+    }
+
+    @Test
+    fun messagePartUpdatedKeepsValidToolAndNonToolParts() {
+        val reducer = EventReducer()
+        val messageId = "msg-1"
+        val parts = listOf(
+            Part.Text(
+                id = "text-1",
+                sessionId = "ses-1",
+                messageId = messageId,
+                text = "hello",
+            ),
+            Part.File(
+                id = "file-1",
+                sessionId = "ses-1",
+                messageId = messageId,
+                filename = "example.txt",
+            ),
+            Part.Unknown(
+                id = "unknown-1",
+                sessionId = "ses-1",
+                messageId = messageId,
+            ),
+            toolPart(id = "tool-1", messageId = messageId, callId = "call-1", tool = "bash"),
+        )
+
+        parts.forEach { part ->
+            reducer.processEvent(SseEvent.MessagePartUpdated(part), serverId = "server-1")
+        }
+
+        assertEquals(parts.map { it.id }, reducer.parts.value[messageId].orEmpty().map { it.id })
+    }
+
+    @Test
+    fun setMessagesDropsOnlyToolPartsWithBlankCallIdOrToolName() {
+        val reducer = EventReducer()
+        val messageId = "msg-1"
+        val keptText = Part.Text(
+            id = "text-1",
+            sessionId = "ses-1",
+            messageId = messageId,
+            text = "hello",
+        )
+        val keptTool = toolPart(id = "tool-1", messageId = messageId, callId = "call-1", tool = "bash")
+        val badCallIdTool = toolPart(id = "missing-call", messageId = messageId, callId = " ", tool = "bash")
+        val badToolNameTool = toolPart(id = "missing-tool", messageId = messageId, callId = "call-2", tool = "")
+
+        reducer.setMessages(
+            sessionId = "ses-1",
+            messages = listOf(
+                MessageWithParts(
+                    info = Message.Assistant(id = messageId, sessionId = "ses-1"),
+                    parts = listOf(keptText, badCallIdTool, keptTool, badToolNameTool),
+                )
+            ),
+        )
+
+        assertEquals(listOf(keptText.id, keptTool.id), reducer.parts.value[messageId].orEmpty().map { it.id })
+    }
+
+    private fun toolPart(
+        id: String,
+        messageId: String,
+        callId: String,
+        tool: String,
+    ) = Part.Tool(
+        id = id,
+        sessionId = "ses-1",
+        messageId = messageId,
+        callId = callId,
+        tool = tool,
+        state = ToolState.Pending(),
+    )
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/domain/model/MessageCompactJsonTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/domain/model/MessageCompactJsonTest.kt
@@ -1,0 +1,67 @@
+package dev.minios.ocremote.domain.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageCompactJsonTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+        explicitNulls = false
+        isLenient = true
+    }
+
+    @Test
+    fun `decodes user message with no time`() {
+        val m = json.decodeFromString(
+            MessageSerializer,
+            """{"role":"user","id":"m1","sessionID":"s1"}"""
+        )
+        assertTrue(m is Message.User)
+        assertEquals(0L, m.time.created)
+    }
+
+    @Test
+    fun `decodes assistant message with no parentID`() {
+        val m = json.decodeFromString(
+            MessageSerializer,
+            """{"role":"assistant","id":"m2","sessionID":"s1"}"""
+        )
+        assertTrue(m is Message.Assistant)
+        assertNull((m as Message.Assistant).parentId)
+        assertEquals(0L, m.time.created)
+    }
+
+    @Test
+    fun `decodes message list mixing user and assistant with missing time`() {
+        val list = json.decodeFromString(
+            kotlinx.serialization.builtins.ListSerializer(MessageSerializer),
+            """[
+                {"role":"user","id":"u1","sessionID":"s"},
+                {"role":"assistant","id":"a1","sessionID":"s","parentID":"u1"}
+            ]"""
+        )
+        assertEquals(2, list.size)
+        assertEquals("u1", list[0].id)
+        assertEquals("u1", (list[1] as Message.Assistant).parentId)
+    }
+
+    @Test
+    fun `full message round-trips (regression)`() {
+        val m = json.decodeFromString(
+            MessageSerializer,
+            """{"role":"assistant","id":"a","sessionID":"s","parentID":"u",
+               "time":{"created":1,"completed":2},"modelID":"gpt","providerID":"openai",
+               "tokens":{"input":1,"output":2,"reasoning":0,"cache":{"read":0,"write":0}}}"""
+        )
+        m as Message.Assistant
+        assertEquals("u", m.parentId)
+        assertEquals(1L, m.time.created)
+        assertEquals("gpt", m.modelId)
+    }
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/domain/model/PartCompactJsonTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/domain/model/PartCompactJsonTest.kt
@@ -1,0 +1,80 @@
+package dev.minios.ocremote.domain.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PartCompactJsonTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+        explicitNulls = false
+        isLenient = true
+    }
+
+    @Test
+    fun `decodes tool part with missing callID tool and state`() {
+        val p = json.decodeFromString(
+            PartSerializer,
+            """{"type":"tool","id":"p1","sessionID":"s","messageID":"m"}"""
+        )
+        assertTrue(p is Part.Tool)
+        p as Part.Tool
+        assertEquals("", p.callId)
+        assertEquals("", p.tool)
+        assertTrue(p.state is ToolState.Pending)
+    }
+
+    @Test
+    fun `decodes file part with no mime`() {
+        val p = json.decodeFromString(
+            PartSerializer,
+            """{"type":"file","id":"p","sessionID":"s","messageID":"m"}"""
+        )
+        assertTrue(p is Part.File)
+        assertEquals("application/octet-stream", (p as Part.File).mime)
+    }
+
+    @Test
+    fun `unknown part type falls back to Unknown subtype`() {
+        val p = json.decodeFromString(
+            PartSerializer,
+            """{"type":"some-future-type","id":"p","sessionID":"s","messageID":"m"}"""
+        )
+        assertTrue(p is Part.Unknown)
+    }
+
+    @Test
+    fun `parts list with mix of valid and compact entries`() {
+        val list = json.decodeFromString(
+            kotlinx.serialization.builtins.ListSerializer(PartSerializer),
+            """[
+                {"type":"text","id":"p1","sessionID":"s","messageID":"m","text":"hi"},
+                {"type":"tool","id":"p2","sessionID":"s","messageID":"m"},
+                {"type":"file","id":"p3","sessionID":"s","messageID":"m"}
+            ]"""
+        )
+        assertEquals(3, list.size)
+        assertTrue(list[0] is Part.Text)
+        assertTrue(list[1] is Part.Tool)
+        assertTrue(list[2] is Part.File)
+    }
+
+    @Test
+    fun `full tool part round-trips (regression)`() {
+        val p = json.decodeFromString(
+            PartSerializer,
+            """{"type":"tool","id":"p","sessionID":"s","messageID":"m",
+               "callID":"call_1","tool":"bash",
+               "state":{"status":"completed","input":{},"output":"ok",
+                        "time":{"start":1,"end":2}}}"""
+        )
+        p as Part.Tool
+        assertEquals("call_1", p.callId)
+        assertEquals("bash", p.tool)
+        assertTrue(p.state is ToolState.Completed)
+    }
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/domain/model/SessionCompactJsonTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/domain/model/SessionCompactJsonTest.kt
@@ -1,0 +1,75 @@
+package dev.minios.ocremote.domain.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SessionCompactJsonTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+        explicitNulls = false
+        isLenient = true
+    }
+
+    @Test
+    fun `decodes session with only id field`() {
+        val s = json.decodeFromString(Session.serializer(), """{"id":"ses_new"}""")
+        assertEquals("ses_new", s.id)
+        assertEquals(0L, s.time.created)
+        assertEquals(0L, s.time.updated)
+        assertNull(s.share)
+        assertNull(s.revert)
+    }
+
+    @Test
+    fun `decodes session with empty share object (missing url)`() {
+        val s = json.decodeFromString(
+            Session.serializer(),
+            """{"id":"s","time":{"created":1,"updated":2},"share":{}}"""
+        )
+        assertNotNull(s.share)
+        assertEquals("", s.share!!.url)
+    }
+
+    @Test
+    fun `decodes revert with no messageID`() {
+        val s = json.decodeFromString(
+            Session.serializer(),
+            """{"id":"s","time":{"created":1,"updated":2},"revert":{}}"""
+        )
+        assertEquals("", s.revert!!.messageId)
+    }
+
+    @Test
+    fun `decodes permission rule with no permission field defaults to ask`() {
+        val s = json.decodeFromString(
+            Session.serializer(),
+            """{"id":"s","time":{"created":1,"updated":2},"permission":[{"pattern":"*"}]}"""
+        )
+        assertEquals(1, s.permission!!.size)
+        assertEquals("ask", s.permission!![0].permission)
+    }
+
+    @Test
+    fun `full response still round-trips fields correctly (regression)`() {
+        val s = json.decodeFromString(
+            Session.serializer(),
+            """{"id":"s","slug":"sl","projectID":"p","directory":"/d","parentID":"par",
+               "title":"T","version":"v1","time":{"created":10,"updated":20,"archived":30},
+               "share":{"url":"https://x"},"revert":{"messageID":"m1","snapshot":"sn"},
+               "permission":[{"permission":"allow","pattern":"git/*","action":"once"}]}"""
+        )
+        assertEquals("s", s.id)
+        assertEquals("p", s.projectId)
+        assertEquals("par", s.parentId)
+        assertEquals("https://x", s.share!!.url)
+        assertEquals("m1", s.revert!!.messageId)
+        assertEquals("allow", s.permission!![0].permission)
+        assertEquals("once", s.permission!![0].action)
+    }
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/domain/model/ToolStateCompactJsonTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/domain/model/ToolStateCompactJsonTest.kt
@@ -1,0 +1,67 @@
+package dev.minios.ocremote.domain.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToolStateCompactJsonTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+        explicitNulls = false
+        isLenient = true
+    }
+
+    @Test
+    fun `unknown status falls back to Pending`() {
+        val s = json.decodeFromString(
+            ToolStateSerializer,
+            """{"status":"some-future-state"}"""
+        )
+
+        assertTrue(s is ToolState.Pending)
+    }
+
+    @Test
+    fun `missing status field falls back to Pending`() {
+        val s = json.decodeFromString(ToolStateSerializer, """{}""")
+
+        assertTrue(s is ToolState.Pending)
+    }
+
+    @Test
+    fun `running with no fields decodes successfully`() {
+        val s = json.decodeFromString(
+            ToolStateSerializer,
+            """{"status":"running"}"""
+        )
+
+        s as ToolState.Running
+        assertEquals("", s.output)
+    }
+
+    @Test
+    fun `completed with minimum fields decodes successfully`() {
+        val s = json.decodeFromString(
+            ToolStateSerializer,
+            """{"status":"completed","time":{"start":1,"end":2}}"""
+        )
+
+        s as ToolState.Completed
+        assertEquals("", s.output)
+    }
+
+    @Test
+    fun `error with minimum fields decodes successfully`() {
+        val s = json.decodeFromString(
+            ToolStateSerializer,
+            """{"status":"error","time":{"start":1,"end":2}}"""
+        )
+
+        s as ToolState.Error
+        assertEquals("", s.error)
+    }
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/ui/screens/chat/ChatNewSessionFirstLoadCompactTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/ui/screens/chat/ChatNewSessionFirstLoadCompactTest.kt
@@ -1,0 +1,197 @@
+package dev.minios.ocremote.ui.screens.chat
+
+import android.content.ContextWrapper
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.lifecycle.SavedStateHandle
+import dev.minios.ocremote.data.api.OpenCodeApi
+import dev.minios.ocremote.data.preferences.SessionListPreferencesRepository
+import dev.minios.ocremote.data.repository.DraftRepository
+import dev.minios.ocremote.data.repository.EventReducer
+import dev.minios.ocremote.data.repository.SettingsRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.Collections
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatNewSessionFirstLoadCompactTest {
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private val json = Json {
+        prettyPrint = true
+        isLenient = true
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `ChatViewModel survives full compact first-load response set`() = runTest(dispatcher) {
+        val requestedPaths = Collections.synchronizedList(mutableListOf<String>())
+        val vm = newViewModel(
+            savedStateHandle = savedStateHandle(sessionId = "ses_new", serverId = "srv-compact"),
+            eventReducer = EventReducer(),
+            api = compactFirstLoadApi(requestedPaths),
+            draftRepository = draftRepository(),
+            sessionListPreferencesRepository = sessionListPreferencesRepository(),
+            settingsRepository = settingsRepository(),
+        )
+
+        val finalState = vm.uiState.first { !it.isLoading }
+
+        assertNull(finalState.error)
+        assertTrue(finalState.providers.isEmpty())
+        assertTrue(finalState.agents.isEmpty())
+        assertTrue(finalState.commands.isEmpty())
+
+        assertTrue(requestedPaths.contains("/session/ses_new"))
+        assertTrue(requestedPaths.contains("/session/ses_new/message"))
+        assertTrue(requestedPaths.contains("/question"))
+        assertTrue(requestedPaths.contains("/config/providers"))
+        assertTrue(requestedPaths.contains("/agent"))
+        assertTrue(requestedPaths.contains("/command"))
+    }
+
+    @Test
+    fun `blank sessionId enters error state and does not call any API`() = runTest(dispatcher) {
+        var requestCount = 0
+        val vm = newViewModel(
+            savedStateHandle = savedStateHandle(sessionId = "", serverId = "srv-blank"),
+            eventReducer = EventReducer(),
+            api = compactFirstLoadApi(onRequest = { requestCount++ }),
+            draftRepository = draftRepository(),
+            sessionListPreferencesRepository = sessionListPreferencesRepository(),
+            settingsRepository = settingsRepository(),
+        )
+
+        val state = vm.uiState.first { !it.isLoading }
+
+        assertFalse(state.isLoading)
+        assertEquals("Invalid session", state.error)
+        assertEquals("blank sessionId should not trigger REST calls", 0, requestCount)
+    }
+
+    private fun savedStateHandle(sessionId: String, serverId: String) = SavedStateHandle(
+        mapOf(
+            "serverUrl" to "http%3A%2F%2Fexample.test%3A4096",
+            "username" to "",
+            "password" to "",
+            "serverName" to "Local",
+            "serverId" to serverId,
+            "sessionId" to sessionId,
+        )
+    )
+
+    private fun compactFirstLoadApi(
+        requestedPaths: MutableList<String> = mutableListOf(),
+        onRequest: () -> Unit = {},
+    ): OpenCodeApi {
+        val engine = MockEngine { request ->
+            onRequest()
+            requestedPaths.add(request.url.encodedPath)
+            val body = when (request.url.encodedPath) {
+                "/session/ses_new" -> """{"id":"ses_new","time":{}}"""
+                "/session/ses_new/message" -> "[]"
+                "/question" -> "[]"
+                "/config/providers" -> "{}"
+                "/agent" -> "[]"
+                "/command" -> "[]"
+                else -> "{}"
+            }
+            respond(
+                content = ByteReadChannel(body),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(json) }
+        }
+        return OpenCodeApi(client, json)
+    }
+
+    private fun draftRepository(): DraftRepository {
+        val filesDir = tmpFolder.newFolder("drafts-${System.nanoTime()}")
+        val context = object : ContextWrapper(null) {
+            override fun getFilesDir(): File = filesDir
+        }
+        return DraftRepository(context)
+    }
+
+    private fun sessionListPreferencesRepository(): SessionListPreferencesRepository {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmpFolder.newFile("session-list-${System.nanoTime()}.preferences_pb") },
+        )
+        return SessionListPreferencesRepository(dataStore)
+    }
+
+    private fun settingsRepository(): SettingsRepository {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmpFolder.newFile("settings-${System.nanoTime()}.preferences_pb") },
+        )
+        val context = object : ContextWrapper(null) {}
+        return SettingsRepository(dataStore, context)
+    }
+
+    private fun newViewModel(
+        savedStateHandle: SavedStateHandle,
+        eventReducer: EventReducer,
+        api: OpenCodeApi,
+        draftRepository: DraftRepository,
+        sessionListPreferencesRepository: SessionListPreferencesRepository,
+        settingsRepository: SettingsRepository,
+    ): ChatViewModel {
+        return ChatViewModel(
+            savedStateHandle = savedStateHandle,
+            eventReducer = eventReducer,
+            api = api,
+            draftRepository = draftRepository,
+            sessionListPreferencesRepository = sessionListPreferencesRepository,
+            settingsRepository = settingsRepository,
+        )
+    }
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModelRouteGuardTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModelRouteGuardTest.kt
@@ -1,0 +1,178 @@
+package dev.minios.ocremote.ui.screens.chat
+
+import android.content.ContextWrapper
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.lifecycle.SavedStateHandle
+import dev.minios.ocremote.data.api.OpenCodeApi
+import dev.minios.ocremote.data.preferences.SessionListPreferencesRepository
+import dev.minios.ocremote.data.repository.DraftRepository
+import dev.minios.ocremote.data.repository.EventReducer
+import dev.minios.ocremote.data.repository.SettingsRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelRouteGuardTest {
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private val json = Json {
+        prettyPrint = true
+        isLenient = true
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `empty sessionId in SavedStateHandle does not crash and surfaces error state`() = runTest(dispatcher) {
+        val handle = savedStateHandle(sessionId = "")
+        var requestCount = 0
+
+        val vm = newViewModel(
+            savedStateHandle = handle,
+            eventReducer = EventReducer(),
+            api = mockApi { requestCount++ },
+            draftRepository = draftRepository(),
+            sessionListPreferencesRepository = sessionListPreferencesRepository(),
+            settingsRepository = settingsRepository(),
+        )
+
+        val state = vm.uiState.first { !it.isLoading }
+        assertFalse("isLoading should not stay true after guard", state.isLoading)
+        assertEquals("Invalid session", state.error)
+        assertEquals("blank sessionId should not trigger REST calls", 0, requestCount)
+    }
+
+    @Test
+    fun `non-blank sessionId proceeds without immediate error`() = runTest(dispatcher) {
+        val vm = newViewModel(
+            savedStateHandle = savedStateHandle(sessionId = "ses_real"),
+            eventReducer = EventReducer(),
+            api = mockApi(),
+            draftRepository = draftRepository(),
+            sessionListPreferencesRepository = sessionListPreferencesRepository(),
+            settingsRepository = settingsRepository(),
+        )
+
+        assertEquals(null, vm.uiState.value.error)
+    }
+
+    private fun savedStateHandle(sessionId: String) = SavedStateHandle(
+        mapOf(
+            "serverUrl" to "http://x",
+            "username" to "",
+            "password" to "",
+            "serverName" to "",
+            "serverId" to "srv",
+            "sessionId" to sessionId,
+        )
+    )
+
+    private fun mockApi(onRequest: () -> Unit = {}): OpenCodeApi {
+        val engine = MockEngine { request ->
+            onRequest()
+            val body = when {
+                request.url.encodedPath.contains("/message") -> "[]"
+                request.url.encodedPath == "/question" -> "[]"
+                request.url.encodedPath == "/config/providers" -> "{}"
+                request.url.encodedPath == "/agent" -> "[]"
+                request.url.encodedPath == "/command" -> "[]"
+                request.url.encodedPath.startsWith("/session/") -> """{"id":"ses_real","time":{}}"""
+                else -> "{}"
+            }
+            respond(
+                content = ByteReadChannel(body),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(json) }
+        }
+        return OpenCodeApi(client, json)
+    }
+
+    private fun draftRepository(): DraftRepository {
+        val filesDir = tmpFolder.newFolder("drafts-${System.nanoTime()}")
+        val context = object : ContextWrapper(null) {
+            override fun getFilesDir(): File = filesDir
+        }
+        return DraftRepository(context)
+    }
+
+    private fun sessionListPreferencesRepository(): SessionListPreferencesRepository {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmpFolder.newFile("session-list-${System.nanoTime()}.preferences_pb") },
+        )
+        return SessionListPreferencesRepository(dataStore)
+    }
+
+    private fun settingsRepository(): SettingsRepository {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmpFolder.newFile("settings-${System.nanoTime()}.preferences_pb") },
+        )
+        val context = object : ContextWrapper(null) {}
+        return SettingsRepository(dataStore, context)
+    }
+
+    private fun newViewModel(
+        savedStateHandle: SavedStateHandle,
+        eventReducer: EventReducer,
+        api: OpenCodeApi,
+        draftRepository: DraftRepository,
+        sessionListPreferencesRepository: SessionListPreferencesRepository,
+        settingsRepository: SettingsRepository,
+    ): ChatViewModel {
+        return ChatViewModel(
+            savedStateHandle = savedStateHandle,
+            eventReducer = eventReducer,
+            api = api,
+            draftRepository = draftRepository,
+            sessionListPreferencesRepository = sessionListPreferencesRepository,
+            settingsRepository = settingsRepository,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Harden Chat startup DTOs against compact OpenCode API responses.
- Add route/session guards so invalid startup data degrades instead of crashing.
- Add regression coverage for compact session/message/provider/question responses.

## Verification
- ANDROID_HOME=/root/Android/Sdk ./gradlew :app:testDebugUnitTest --tests <focused new/changed tests>
- ANDROID_HOME=/root/Android/Sdk ./gradlew :app:lintDebug
- ANDROID_HOME=/root/Android/Sdk ./gradlew :app:assembleDebug
- ANDROID_HOME=/root/Android/Sdk ./gradlew :app:testDebugUnitTest

Closes #27.